### PR TITLE
ci: 👷 dependabot config added

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Automatic dependency bot needs to enable via repo settings and here is the quick start URL

https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide  