### PR TITLE
Testing Update

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -211,7 +211,44 @@ impl Request {
         self.params.get(key)
     }
 
+    /// Returns the version of the HTTP request
+    /// 
+    /// # Example
+    /// 
+    /// ```rust
+    /// use krustie::{HttpMethod, Request, Response};
+    /// 
+    /// # let request = Request::builder()
+    /// #  .request_line(HttpMethod::GET, "/echo/hello", "HTTP/1.1")
+    /// #  .build();
+    /// #
+    /// fn get(request: &Request, response: &mut Response) {
+    /// # }
+    ///     assert_eq!(request.get_version(), "HTTP/1.1");
+    /// # {
+    /// }
+    /// ```
+    pub fn get_version(&self) -> &str {
+        &self.request.get_version()
+    }
+
     /// Returns the method of the HTTP request
+    /// 
+    /// # Example
+    /// 
+    /// ```rust
+    /// use krustie::{HttpMethod, Request, Response};
+    /// 
+    /// # let request = Request::builder()
+    /// #  .request_line(HttpMethod::GET, "/echo/hello", "HTTP/1.1")
+    /// #  .build();
+    /// #
+    /// fn get(request: &Request, response: &mut Response) {
+    /// # }
+    ///    assert_eq!(request.get_method(), &HttpMethod::GET);
+    /// # {
+    /// }
+    /// ```
     pub fn get_method(&self) -> &HttpMethod {
         self.request.get_method()
     }
@@ -237,24 +274,17 @@ impl Default for Request {
 
 impl Debug for Request {
     fn fmt(&self, f: &mut Formatter<'_>) -> fResult {
-        let headers = self
-            .headers
-            .iter()
-            .map(|(k, v)| format!("  {k}: {v}"))
-            .collect::<Vec<String>>()
-            .join("\r\n");
-        let params = self
-            .params
-            .iter()
-            .map(|(k, v)| format!("  {k}: {v}"))
-            .collect::<Vec<String>>()
-            .join("\r\n");
-        let queries = self
-            .queries
-            .iter()
-            .map(|(k, v)| format!("  {k}: {v}"))
-            .collect::<Vec<String>>()
-            .join("\r\n");
+        fn format_hashmap(value: &HashMap<String, String>) -> String {
+            value
+                .iter()
+                .map(|(k, v)| format!("  {}: {}", k, v))
+                .collect::<Vec<String>>()
+                .join("\r\n")
+        }
+
+        let headers = format_hashmap(&self.headers);
+        let params = format_hashmap(&self.params);
+        let queries = format_hashmap(&self.queries);
         let body = match &self.body {
             RequestBody::Text(string) => format!("{:?}", string),
             RequestBody::Json(json) => format!("{:?}", json),

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,6 +12,7 @@ use std::{
 pub use body::RequestBody;
 
 pub mod body;
+pub mod builder;
 pub mod http_method;
 pub(crate) mod parser;
 mod request_line;

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -10,7 +10,7 @@ use std::io::{Error, ErrorKind};
 
 use crate::json::JsonValue;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 // TODO: Add doctests
 /// Represents the body of the HTTP request
 pub enum RequestBody {

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -1,0 +1,94 @@
+//! RequestBuilder module
+//!
+//! This module contains the `RequestBuilder` struct and its implementation.
+
+use crate::HttpMethod;
+
+use super::{Request, RequestBody};
+
+#[derive(Debug)]
+pub struct RequestBuilder {
+    request: Request,
+}
+
+/// A builder for the `Request` struct
+///
+/// This builder is used to create a `Request` struct to be used in testing.
+impl RequestBuilder {
+    fn new() -> Self {
+        Self {
+            request: Request::default(),
+        }
+    }
+
+    pub fn request_line(&mut self, method: HttpMethod, path: &str, version: &str) -> &mut Self {
+        self.request.set_method(method);
+        self.request.set_uri(path);
+        self.request.set_version(version);
+        self
+    }
+
+    pub fn method(&mut self, method: HttpMethod) -> &mut Self {
+        self.request.set_method(method);
+        self
+    }
+
+    pub fn path(&mut self, path: &str) -> &mut Self {
+        self.request.set_uri(path);
+        self
+    }
+
+    pub fn version(&mut self, version: &str) -> &mut Self {
+        self.request.set_version(version);
+        self
+    }
+
+    pub fn header(&mut self, key: &str, value: &str) -> &mut Self {
+        self.request.set_header(key, value);
+        self
+    }
+
+    pub fn headers(&mut self, headers: Vec<(&str, &str)>) -> &mut Self {
+        for (key, value) in headers {
+            self.request.set_header(key, value);
+        }
+        self
+    }
+
+    pub fn body(&mut self, body: RequestBody) -> &mut Self {
+        self.request.set_body(body);
+        self
+    }
+
+    pub fn build(&self) -> Request {
+        self.request.clone()
+    }
+}
+
+impl Request {
+    // TODO: Add doctest
+    /// Returns a new RequestBuilder instance
+    pub fn builder() -> RequestBuilder {
+        RequestBuilder::new()
+    }
+
+    fn set_method(&mut self, method: HttpMethod) {
+        self.request.set_method(method);
+    }
+
+    fn set_uri(&mut self, path: &str) {
+        self.request.set_uri(path);
+    }
+
+    fn set_version(&mut self, version: &str) {
+        self.request.set_version(version);
+    }
+
+    fn set_header(&mut self, key: &str, value: &str) {
+        self.headers.insert(key.to_string(), value.to_string());
+    }
+
+    fn set_body(&mut self, body: RequestBody) {
+        self.body = body;
+    }
+}

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -6,14 +6,34 @@ use crate::HttpMethod;
 
 use super::{Request, RequestBody};
 
+/// RequestBuilder
+///
+/// A builder for the `Request` struct
+///
+/// This builder is used to create a `Request` struct to be used in testing.
+///
+/// # Example
+///
+/// ```
+/// use krustie::{HttpMethod, Request, request::RequestBody};
+///
+/// let request = Request::builder()
+///   .method(HttpMethod::GET)
+///   .path("/echo/hello")
+///   .header("Content-Type", "application/json")
+///   .body(RequestBody::Text("Hello, World!".to_string()))
+///   .build();
+///
+/// assert_eq!(request.get_method(), &HttpMethod::GET);
+/// assert_eq!(request.get_path(), "/echo/hello");
+/// assert_eq!(request.get_header("Content-Type"), Some("application/json"));
+/// assert_eq!(request.get_body(), &RequestBody::Text("Hello, World!".to_string()));
+/// ```
 #[derive(Debug)]
 pub struct RequestBuilder {
     request: Request,
 }
 
-/// A builder for the `Request` struct
-///
-/// This builder is used to create a `Request` struct to be used in testing.
 impl RequestBuilder {
     fn new() -> Self {
         Self {
@@ -21,6 +41,21 @@ impl RequestBuilder {
         }
     }
 
+    /// Sets the request line of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .request_line(HttpMethod::GET, "/echo/hello", "HTTP/1.1")
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_method(), &HttpMethod::GET);
+    /// assert_eq!(request.get_path(), "/echo/hello");
+    /// assert_eq!(request.get_version(), "HTTP/1.1");
+    /// ```
     pub fn request_line(&mut self, method: HttpMethod, path: &str, version: &str) -> &mut Self {
         self.request.set_method(method);
         self.request.set_uri(path);
@@ -28,26 +63,92 @@ impl RequestBuilder {
         self
     }
 
+    /// Sets the method of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .method(HttpMethod::GET)
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_method(), &HttpMethod::GET);
+    /// ```
     pub fn method(&mut self, method: HttpMethod) -> &mut Self {
         self.request.set_method(method);
         self
     }
 
+    /// Sets the path of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .path("/echo/hello")
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_path(), "/echo/hello");
+    /// ```
     pub fn path(&mut self, path: &str) -> &mut Self {
         self.request.set_uri(path);
         self
     }
 
+    /// Sets the version of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .version("HTTP/1.1")
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_version(), "HTTP/1.1");
+    /// ```
     pub fn version(&mut self, version: &str) -> &mut Self {
         self.request.set_version(version);
         self
     }
 
+    /// Sets the header of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .header("Content-Type", "application/json")
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_header("Content-Type"), Some("application/json"))
+    /// ```
     pub fn header(&mut self, key: &str, value: &str) -> &mut Self {
         self.request.set_header(key, value);
         self
     }
 
+    /// Sets the headers of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .headers(vec![("Content-Type", "application/json"), ("Server", "Krustie")])
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_header("Content-Type"), Some("application/json"));
+    /// assert_eq!(request.get_header("Server"), Some("Krustie"));
+    /// ```
     pub fn headers(&mut self, headers: Vec<(&str, &str)>) -> &mut Self {
         for (key, value) in headers {
             self.request.set_header(key, value);
@@ -55,19 +156,58 @@ impl RequestBuilder {
         self
     }
 
+    /// Sets the body of the HTTP request
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request, request::RequestBody};
+    ///
+    /// let request = Request::builder()
+    ///   .body(RequestBody::Text("Hello, World!".to_string()))
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_body(), &RequestBody::Text("Hello, World!".to_string()));
+    /// ```
     pub fn body(&mut self, body: RequestBody) -> &mut Self {
         self.request.set_body(body);
         self
     }
 
+    /// Builds the `Request` struct
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use krustie::{HttpMethod, Request};
+    ///
+    /// let request = Request::builder()
+    ///   .method(HttpMethod::GET)
+    ///   .path("/echo/hello")
+    ///   .build();
+    ///
+    /// assert_eq!(request.get_method(), &HttpMethod::GET);
+    /// assert_eq!(request.get_path(), "/echo/hello");
+    /// ```
     pub fn build(&self) -> Request {
         self.request.clone()
     }
 }
 
 impl Request {
-    // TODO: Add doctest
     /// Returns a new RequestBuilder instance
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// use krustie::{Request, HttpMethod};
+    /// 
+    /// let request = Request::builder()
+    ///   .method(HttpMethod::GET)
+    ///   .build();
+    /// 
+    /// assert_eq!(request.get_method(), &HttpMethod::GET);
+    /// ```
     pub fn builder() -> RequestBuilder {
         RequestBuilder::new()
     }

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -218,6 +218,7 @@ impl Request {
 
     fn set_uri(&mut self, path: &str) {
         self.request.set_uri(path);
+        self.queries = Request::parse_queries(&self.request.get_path_array());
     }
 
     fn set_version(&mut self, version: &str) {

--- a/src/request/request_line.rs
+++ b/src/request/request_line.rs
@@ -5,25 +5,23 @@ use super::http_method::HttpMethod;
 #[derive(Clone)]
 pub(crate) struct RequestLine {
     method: HttpMethod,
-    request_uri: String,
+    uri: String,
     version: String,
-    request_uri_array: Vec<String>,
+    path_array: Vec<String>,
 }
 
 impl RequestLine {
     pub(super) fn new(
         method: &str,
-        request_uri: &str,
+        uri: &str,
         version: &str,
     ) -> Result<Self, ParseRequestLineError> {
-        println!("{:?}", Self::request_uri_parser(request_uri));
-
         match HttpMethod::try_from(method) {
             Ok(method) => Ok(Self {
                 method,
-                request_uri: request_uri.to_string(),
+                uri: uri.to_string(),
                 version: version.to_string(),
-                request_uri_array: Self::request_uri_parser(request_uri),
+                path_array: Self::uri_parser(uri),
             }),
             Err(_) => {
                 return Err(ParseRequestLineError);
@@ -31,7 +29,7 @@ impl RequestLine {
         }
     }
 
-    fn request_uri_parser(uri: &str) -> Vec<String> {
+    fn uri_parser(uri: &str) -> Vec<String> {
         if uri.starts_with('/') {
             uri.split('/').skip(1).map(|str| str.to_string()).collect()
         } else if uri.starts_with("http") {
@@ -46,7 +44,7 @@ impl RequestLine {
     }
 
     pub(super) fn get_path_array(&self) -> &Vec<String> {
-        &self.request_uri_array
+        &self.path_array
     }
 
     pub(super) fn get_version(&self) -> &String {
@@ -54,13 +52,26 @@ impl RequestLine {
     }
 
     pub(super) fn get_path(&self) -> &str {
-        &self.request_uri.as_str()
+        &self.uri.as_str()
+    }
+
+    pub(crate) fn set_method(&mut self, method: HttpMethod) {
+        self.method = method;
+    }
+
+    pub(crate) fn set_uri(&mut self, uri: &str) {
+        self.uri = String::from(uri);
+        self.path_array = Self::uri_parser(uri);
+    }
+
+    pub(crate) fn set_version(&mut self, version: &str) {
+        self.version = String::from(version.trim());
     }
 }
 
 impl Display for RequestLine {
     fn fmt(&self, f: &mut Formatter<'_>) -> fResult {
-        write!(f, "{} {} {}", self.method, self.request_uri, self.version)
+        write!(f, "{} {} {}", self.method, self.uri, self.version)
     }
 }
 
@@ -76,7 +87,13 @@ impl TryFrom<&str> for RequestLine {
             return Err(ParseRequestLineError);
         }
 
-        match Self::new(request_line[0].trim(), request_line[1].trim(), request_line[2].trim()) {
+        let (method, uri, version) = (
+            request_line[0].trim(),
+            request_line[1].trim(),
+            request_line[2].trim(),
+        );
+
+        match Self::new(method, uri, version) {
             Ok(request_line) => Ok(request_line),
             Err(_) => Err(ParseRequestLineError),
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -34,6 +34,7 @@ pub use self::content_type::ContentType;
 pub mod body;
 pub mod content_type;
 pub mod status_code;
+pub mod testing;
 pub mod utilities;
 
 /// Represents the HTTP response
@@ -107,6 +108,47 @@ impl Response {
         }
         self
     }
+
+    fn export_request_header(&self) -> String {
+        let mut headers_string = String::new();
+
+        if !self.headers.is_empty() {
+            let mut keys = self.headers.keys().collect::<Vec<&String>>();
+            keys.sort();
+
+            keys.iter().for_each(|key| {
+                headers_string.push_str(&format!("{key}: {}\r\n", self.headers[*key]));
+            });
+        }
+
+        if !self.body.is_empty() {
+            headers_string.push_str(&format!("Content-Length: {}\r\n", self.body.len()));
+
+            if !headers_string.contains("Content-Type") {
+                eprintln!("Content-Type not found even though body is present");
+                headers_string.push_str("Content-Type: text/plain\r\n");
+            }
+        }
+
+        return format!(
+            "{http_version} {status_code} {status_msg}\r\n{headers_string}\r\n",
+            http_version = self.http_version,
+            status_code = self.status_code,
+            status_msg = self.status_code.get_message()
+        );
+    }
+}
+
+impl ToString for Response {
+    fn to_string(&self) -> String {
+        let mut response_string = self.export_request_header();
+
+        if !self.body.is_empty() {
+            response_string.push_str(&String::from_utf8_lossy(&self.body));
+        }
+
+        response_string
+    }
 }
 
 impl From<Response> for Vec<u8> {
@@ -122,41 +164,9 @@ impl From<Response> for Vec<u8> {
     /// }
     /// ```
     fn from(response: Response) -> Vec<u8> {
-        let mut headers = response.headers;
-        let mut headers_string = String::new();
+        let mut response_bytes = response.export_request_header().into_bytes();
 
         if !response.body.is_empty() {
-            headers.insert(
-                "Content-Length".to_string(),
-                response.body.len().to_string(),
-            );
-
-            if !headers.contains_key("Content-Type") {
-                eprintln!("Content-Type not found even though body is present");
-                headers.insert("Content-Type".to_string(), "text/plain".to_string());
-            }
-        }
-
-        if !headers.is_empty() {
-            let mut headers_vec: Vec<String> = Vec::new();
-
-            headers.iter().for_each(|(key, value)| {
-                headers_vec.push(format!("{key}: {value}"));
-            });
-
-            headers_string = headers_vec.join("\r\n");
-        }
-
-        let mut response_bytes: Vec<u8> = format!(
-            "{http_version} {status_code} {status_msg}\r\n{headers_string}\r\n",
-            http_version = response.http_version,
-            status_code = response.status_code,
-            status_msg = response.status_code.get_message()
-        )
-        .into_bytes();
-
-        if !response.body.is_empty() {
-            response_bytes.extend_from_slice(b"\r\n");
             response_bytes.extend_from_slice(&response.body);
         }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -110,24 +110,26 @@ impl Response {
     }
 
     fn export_request_header(&self) -> String {
+        let mut headers = self.headers.clone();
         let mut headers_string = String::new();
 
-        if !self.headers.is_empty() {
-            let mut keys = self.headers.keys().collect::<Vec<&String>>();
-            keys.sort();
+        if !self.body.is_empty() {
+            headers.insert("Content-Length".to_string(), self.body.len().to_string());
 
-            keys.iter().for_each(|key| {
-                headers_string.push_str(&format!("{key}: {}\r\n", self.headers[*key]));
-            });
+            if !headers.contains_key("Content-Type") {
+                eprintln!("Content-Type not found even though body is present");
+
+                headers.insert("Content-Type".to_string(), "text/plain".to_string());
+            }
         }
 
-        if !self.body.is_empty() {
-            headers_string.push_str(&format!("Content-Length: {}\r\n", self.body.len()));
+        if !headers.is_empty() {
+            let mut keys = headers.keys().collect::<Vec<&String>>();
+            keys.sort();
 
-            if !headers_string.contains("Content-Type") {
-                eprintln!("Content-Type not found even though body is present");
-                headers_string.push_str("Content-Type: text/plain\r\n");
-            }
+            headers_string = keys.iter().fold(String::new(), |acc, key| {
+                format!("{acc}{key}: {value}\r\n", value = headers[*key])
+            });
         }
 
         return format!(

--- a/src/response/testing.rs
+++ b/src/response/testing.rs
@@ -1,6 +1,20 @@
+//! This module contains testing utilities for the response module.
+
 use super::Response;
 
 impl Response {
+    /// Compares two responses and asserts that they are equal
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use krustie::Response;
+    ///
+    /// let response1 = Response::default();
+    /// let response2 = Response::default();
+    ///
+    /// Response::assert_eq(&response1, &response2);
+    /// ```
     pub fn assert_eq(resp1: &Response, resp2: &Response) {
         assert_eq!(&resp1.get_status(), &resp2.get_status());
         let _ = &resp1.get_headers().iter().for_each(|(key, value)| {

--- a/src/response/testing.rs
+++ b/src/response/testing.rs
@@ -1,0 +1,11 @@
+use super::Response;
+
+impl Response {
+    pub fn assert_eq(resp1: &Response, resp2: &Response) {
+        assert_eq!(&resp1.get_status(), &resp2.get_status());
+        let _ = &resp1.get_headers().iter().for_each(|(key, value)| {
+            assert_eq!(resp2.get_headers().get(key), Some(value));
+        });
+        assert_eq!(&resp1.get_body(), &resp2.get_body());
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,6 +93,7 @@ use std::{
 };
 
 pub mod route_handler;
+pub mod testing;
 use route_handler::{HandlerResult, RouteHandler};
 use std::thread;
 

--- a/src/server/testing.rs
+++ b/src/server/testing.rs
@@ -1,3 +1,5 @@
+//! Testing utilities for the server
+
 use crate::{Request, Response};
 
 use super::{route_handler::HandlerResult, Server};
@@ -35,4 +37,3 @@ impl Server {
         Response::assert_eq(&response, &expected_response);
     }
 }
-

--- a/src/server/testing.rs
+++ b/src/server/testing.rs
@@ -1,0 +1,38 @@
+use crate::{Request, Response};
+
+use super::{route_handler::HandlerResult, Server};
+
+impl Server {
+    /// Mocks a request and returns a response
+    ///
+    /// This method is useful for testing the server without actually listening on a port.
+    pub fn mock_request(&mut self, request: Request) -> Response {
+        let mut response = Response::default();
+
+        for handler in &mut self.route_handlers {
+            let result = handler.handle(&request, &mut response);
+            if result == HandlerResult::End {
+                break;
+            }
+        }
+
+        response
+    }
+
+    /// Mocks a request and expects a specific response
+    ///
+    /// This method is useful for testing the server without actually listening on a port.
+    pub fn mock_request_and_expect(&mut self, request: Request, expected_response: Response) {
+        let mut response = Response::default();
+
+        for handler in &mut self.route_handlers {
+            let result = handler.handle(&request, &mut response);
+            if result == HandlerResult::End {
+                break;
+            }
+        }
+
+        Response::assert_eq(&response, &expected_response);
+    }
+}
+

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+use krustie::{json, Response, StatusCode};
+
+#[test]
+fn serialize_response() {
+    let mut default_response = Response::default();
+    let mut headers = HashMap::new();
+
+    headers.insert(String::from("Hello"), String::from("World"));
+    headers.insert(String::from("Meaning of the life"), String::from("42"));
+
+    let response = default_response
+        .status(StatusCode::Ok)
+        .set_header("Server", "Krustie")
+        .headers(headers)
+        .body_json(json::json!({"message": "Hello, World!"}));
+
+    assert_eq!(
+        "HTTP/1.1 200 OK\r\nContent-Length: 27\r\nContent-Type: application/json\r\nHello: World\r\nMeaning of the life: 42\r\nServer: Krustie\r\n\r\n{\"message\":\"Hello, World!\"}",
+        response.to_string()
+    );
+}

--- a/tests/router.rs
+++ b/tests/router.rs
@@ -1,0 +1,83 @@
+use krustie::{HttpMethod, Request, Response, Router, Server, StatusCode};
+
+#[test]
+fn router_parameters() {
+    // Create a new server instance
+    let mut server = Server::create();
+    let mut router = Router::new();
+
+    router.get("/echo/:param", |req, res| {
+        res.status(StatusCode::Ok).body_text(req.get_param("param").unwrap());
+    });
+
+    server.use_handler(router);
+
+    // Test the router
+    let mut expected_response = Response::default();
+    expected_response.status(StatusCode::Ok).body_text("hello");
+
+    let request = Request::builder()
+        .method(HttpMethod::GET)
+        .path("/echo/hello")
+        .build();
+
+
+    let response = server.mock_request(request);
+
+    Response::assert_eq(&expected_response, &response);
+}
+
+#[test]
+fn query_parameters() {
+    // Create a new server instance
+    let mut server = Server::create();
+    let mut router = Router::new();
+
+    router.get("/echo", |req, res| {
+        res.status(StatusCode::Ok).body_text(req.get_query_param("query").unwrap());
+    });
+
+    server.use_handler(router);
+
+    // Test the router
+    let mut expected_response = Response::default();
+    expected_response.status(StatusCode::Ok).body_text("world");
+
+    let request = Request::builder()
+        .method(HttpMethod::GET)
+        .path("/echo?query=world")
+        .build();
+
+    let response = server.mock_request(request);
+
+    Response::assert_eq(&expected_response, &response);
+}
+
+
+
+#[test]
+fn router_and_query_parameters() {
+    // Create a new server instance
+    let mut server = Server::create();
+    let mut router = Router::new();
+
+    router.get("/echo/:param", |req, res| {
+        res.status(StatusCode::Ok).body_text(format!("{} {}", req.get_param("param").unwrap(), req.get_query_param("query").unwrap()).as_str());
+    });
+
+    server.use_handler(router);
+
+    // Test the router
+    let mut expected_response = Response::default();
+    expected_response.status(StatusCode::Ok).body_text("hello world");
+
+    let request = Request::builder()
+        .method(HttpMethod::GET)
+        .path("/echo/hello?query=world")
+        .build();
+
+    let response = server.mock_request(request);
+
+    Response::assert_eq(&expected_response, &response);
+}
+


### PR DESCRIPTION
* Added `RequestBuilder` to create HTTP requests to use in tests.
* Added `Server::mock_request()` and `Server::mock_request_and_expect()` methods to test servers
* Added `Response::assert_eq()` method for comparing responses
* Add tests for request uri parsing and response serializer
* Updated RequestLine to add new methods such as `Request::set_method`, `Request::set_uri`, `Request::set_version` that can be used to write tests.
* Updated response parser to sort headers by letters
* Moved query parameter parsing to another function to fix the parsing for `Request::set_uri()` function